### PR TITLE
Replay tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,6 @@ ASALocalRun/
 
 # vscode specific folder
 .vscode/
+
+# local dev specific
+run.sh

--- a/TASMod/Assets/lua/core/input.lua
+++ b/TASMod/Assets/lua/core/input.lua
@@ -15,7 +15,7 @@ function input.click_point(point, left, right)
         left=false,
         right=false
     }
-    local last_mouse = RunCS("Controller.LastFrameMouse()")
+    local last_mouse = Controller.LastFrameMouse()
     if last_mouse.X ~= mouse.X or last_mouse.Y ~= mouse.Y  or (last_mouse.LeftMouseClicked and left) or (last_mouse.RightMouseClicked and right) then
         advance({mouse=mouse})
     end

--- a/TASMod/Controller.cs
+++ b/TASMod/Controller.cs
@@ -40,6 +40,7 @@ namespace TASMod
         public static bool FastAdvance = false;
         public static bool AcceptRealInput = true;
         public static int FramesBetweenRender = 60;
+        public static int PlaybackFrame = -1;
         public static bool SkipSave = true;
         public static int PauseFrame = 0;
         public static bool IsPaused = false;

--- a/TASMod/Controller.cs
+++ b/TASMod/Controller.cs
@@ -32,6 +32,7 @@ namespace TASMod
         Loaded,
         Finalized
     }
+
 	public class Controller
 	{
         public static LaunchState LaunchState = LaunchState.None;
@@ -40,6 +41,9 @@ namespace TASMod
         public static bool AcceptRealInput = true;
         public static int FramesBetweenRender = 60;
         public static bool SkipSave = true;
+        public static int PauseFrame = 0;
+        public static bool IsPaused = false;
+
         public static PerformanceTiming Timing;
         public static TASMouseState LogicMouse = null;
         public static TASKeyboardState LogicKeyboard = null;
@@ -125,6 +129,29 @@ namespace TASMod
 
 		public static bool Update()
 		{
+            if (LaunchUpdate()) return true;
+
+			RealInputState.Update();
+            Console.Update();
+            bool didInjectText = HandleTextBoxEntry();
+            UpdateOverlays();
+
+            TASInputState.Active = false;
+            switch(GameMode)
+            {
+                case TASMode.Edit:
+                    EditUpdate(didInjectText);
+                    break;
+                case TASMode.Replay:
+                    ReplayUpdate(didInjectText);
+                    break;
+            }
+
+			return TASInputState.Active;
+		}
+
+        public static bool LaunchUpdate()
+        {
             switch (LaunchState)
             {
                 case LaunchState.None:
@@ -140,14 +167,72 @@ namespace TASMod
                     Reset();
                     LaunchState = LaunchState.Finalized;
                     return false;
+                case LaunchState.Finalized:
+                default:
+                    return false;
             }
-			TASInputState.Active = false;
-			RealInputState.Update();
-            Console.Update();
-            bool didInjectText = HandleTextBoxEntry();
+        }
 
-            UpdateOverlays();
+        public static void ReplayUpdate(bool didInjectText)
+        {
+            // you can't pause on inject text frames
+            if (didInjectText)
+            {
+                // advance if we have a frame to pull
+                if(HandleStoredInput())
+                {
+                    PullFrame();
+                }
+                return;
+            }
 
+            // only allow release if we're on the main game view
+            if (CurrentView != TASView.None)
+            {
+                return;
+            }
+
+            if (!Console.IsOpen)
+            {
+                if (RealInputState.KeyTriggered(Keys.P))
+                {
+                    IsPaused = !IsPaused;
+                    if (!IsPaused && HandleStoredInput()) { PullFrame(); }
+                    return;
+                }
+                else if (HandleRealInput())
+                {
+                    if (HandleStoredInput())
+                    {
+                        PullFrame();
+                    }
+                    return;
+                }
+            }
+            if (ResetGame)
+            {
+                IsPaused = false;
+                return;
+            }
+
+            // advance until we reach the pause frame
+            if (!IsPaused)
+            {
+                if (PauseFrame == (int)TASDateTime.CurrentFrame)
+                {
+                    IsPaused = true;
+                    return;
+                }
+                // advance if we have a frame to pull
+                if (HandleStoredInput())
+                {
+                    PullFrame();
+                }
+            }
+        }
+
+        public static void EditUpdate(bool didInjectText)
+        {
             if (HandleStoredInput())
             {
                 FrameState state = PullFrame();
@@ -156,10 +241,7 @@ namespace TASMod
                     && TASDateTime.CurrentFrame > 3000)
                 {
                     ModEntry.Console.Log(string.Format("{0}: Game1.random: [{1}]\tFrame: {2}", TASDateTime.CurrentFrame, Game1.random.ToString(), state.randomState), StardewModdingAPI.LogLevel.Error);
-                    //Game1.game1.Exit();
-                    //Environment.Exit(1);
                 }
-                // compare randoms
             }
             else if (didInjectText)
             {
@@ -179,8 +261,7 @@ namespace TASMod
                 TASInputState.SetMouse(RealMouse);
                 PushFrame();
             }
-			return TASInputState.Active;
-		}
+        }
 
         public static void UpdateOverlays()
         {
@@ -279,6 +360,7 @@ namespace TASMod
             TASInputState.Reset();
             TASDateTime.Reset();
             TASGuid.Reset();
+            IsPaused = false;
         }
         #endregion
 
@@ -359,6 +441,21 @@ namespace TASMod
                     State = state;
                     Reset(false);
                     advance = false;
+                }
+            }
+            if (RealInputState.KeyTriggered(Keys.M))
+            {
+                switch(GameMode)
+                {
+                    case TASMode.Edit:
+                        if (!HandleStoredInput())
+                        {
+                            GameMode = TASMode.Replay;
+                        }
+                        break;
+                    case TASMode.Replay:
+                        GameMode = TASMode.Edit;
+                        break;
                 }
             }
             if (RealInputState.KeyTriggered(Keys.OemPipe))

--- a/TASMod/Extensions/GameRunner.cs
+++ b/TASMod/Extensions/GameRunner.cs
@@ -128,7 +128,10 @@ namespace TASMod.Extensions
             int counter = 0;
             int finalFrames = 10;
             TASSpriteBatch.Active = false;
-            while ((int)TASDateTime.CurrentFrame < Controller.State.Count - finalFrames)
+            int maxFrame = Controller.State.Count - finalFrames;
+            if (Controller.PlaybackFrame != -1)
+                maxFrame = Math.Min(maxFrame, Controller.PlaybackFrame);
+            while ((int)TASDateTime.CurrentFrame < maxFrame)
             {
                 try
                 {

--- a/TASMod/Extensions/GameRunner.cs
+++ b/TASMod/Extensions/GameRunner.cs
@@ -132,13 +132,18 @@ namespace TASMod.Extensions
             {
                 try
                 {
+                    if ((int)TASDateTime.CurrentFrame + 2 > Controller.PauseFrame && Controller.GameMode == TASMode.Replay)
+                    {
+                        counter = 0;
+                        break;
+                    }
                     //ModEntry.Console.Log($"Reset {TASDateTime.CurrentFrame}", LogLevel.Error);
                     //runner.Step();
                     GameTime gameTime = TASDateTime.CurrentGameTime;
                     runner.InvokeUpdate(gameTime);
                     runner.InvokeDraw(gameTime);
                     runner.EventLoop();
-                    if (counter++ >= Controller.FramesBetweenRender)
+                    if (counter++ >= Controller.FramesBetweenRender && (Controller.GameMode == TASMode.Edit || !Controller.IsPaused))
                         break;
                 } catch
                 {
@@ -148,7 +153,7 @@ namespace TASMod.Extensions
             }
             //ModEntry.Console.Log($"CurrentFrame: {TASDateTime.CurrentFrame}", LogLevel.Warn);
             TASSpriteBatch.Active = true;
-            if ((int)TASDateTime.CurrentFrame < Controller.State.Count - finalFrames)
+            if (counter >= Controller.FramesBetweenRender)
                 Controller.FastAdvance = true;
         }
 

--- a/TASMod/LuaScripting/LuaEngine.cs
+++ b/TASMod/LuaScripting/LuaEngine.cs
@@ -45,6 +45,7 @@ namespace TASMod.LuaScripting
                 import ('TASMod')
                 import ('TASMod.Helpers')
                 import ('TASMod.Extensions')
+                import ('TASMod.Overlays')
             ");
         }
 
@@ -66,7 +67,6 @@ namespace TASMod.LuaScripting
 
         public static void RegisterStaticClasses()
         {
-            LuaState["Controller"] = Activator.CreateInstance(typeof(Controller));
             LuaState.RegisterFunction("RunCS", typeof(CSInterpreter).GetMethod("Eval"));
             LuaState.RegisterFunction("GetValue", typeof(Reflector).GetMethod("GetDynamicCastField"));
         }

--- a/TASMod/Patches/GameRunner.cs
+++ b/TASMod/Patches/GameRunner.cs
@@ -173,7 +173,14 @@ namespace TASMod.Patches
             if (Controller.FastAdvance)
             {
                 //ModEntry.Console.Log("Calling fast advance", LogLevel.Error);
-                __instance.RunFast();
+                if (Controller.PlaybackFrame == -1 || (int)TASDateTime.CurrentFrame < Controller.PlaybackFrame)
+                {
+                    __instance.RunFast();
+                }
+                else
+                {
+                    Controller.FastAdvance = false;
+                }
                 return false;
             }
             if (GameRunner_Draw.Counter != Counter)

--- a/TASMod/Recording/SaveState.cs
+++ b/TASMod/Recording/SaveState.cs
@@ -149,6 +149,7 @@ namespace TASMod.Recording
 
         public void Reset(int resetTo)
         {
+            if (Controller.GameMode != TASMode.Edit) return;
             if (resetTo < 0)
                 resetTo = FrameStates.Count + 1 + resetTo;
             resetTo = Math.Min(resetTo, FrameStates.Count);


### PR DESCRIPTION
adds a few extra variables to Controller/a new "mode" for replaying an input stream

* `Controller.GameMode` can be `TASMode.Edit` (standard) or `TASMod.Replay` (allows pausing)
  * default keybind is M to swap between modes
  * in replay mode you can press `P` to toggle pause/unpause state, during pause, normal advance keys like `Q`,`Space`,`Down` will pull through frames as expected
  * Cannot pause on inject frames (would cause some serious wonk)
  * can jump into map view but can't unpause while in the map view
* `Controller.PlaybackFrame` (default is `-1` or advance to the end) allows setting a frame to fast advance to before returning to normal speed advancing
  * does *not* work with lua `breset` or `bfreset`

also tweaked the Controller so functions like `LastFrameMouse()` can be called directly and you don't need to pre-call variables on the Controller to expose them into lua

eg: don't need to call `Controller.SkipSave` before calling `Controller.SkipSave=false`