### PR TITLE
add better textbox support

### DIFF
--- a/TASMod/Console/Commands/WriteTextBox.cs
+++ b/TASMod/Console/Commands/WriteTextBox.cs
@@ -1,0 +1,25 @@
+using TASMod.Console;
+using TASMod.Overlays;
+
+namespace TASMod.Console.Commands
+{
+    public class WriteTextBox : IConsoleCommand
+    {
+        public override string Name => "textbox";
+        public override string Description => "Insert a value into the specified textbox";
+        public override string[] Usage => new string[] 
+        {
+            string.Format("{0} value", Name),
+        };
+
+        public override void Run(string[] tokens)
+        {
+            if (tokens.Length != 1)
+            {
+                Write(HelpText());
+                return;
+            }
+            Controller.PushTextFrame(tokens[0]);
+        }
+    }
+}

--- a/TASMod/Controller.cs
+++ b/TASMod/Controller.cs
@@ -350,6 +350,20 @@ namespace TASMod
             );
             TASInputState.Active = true;
         }
+        public static void PushTextFrame(string text)
+        {
+            var mState = LastFrameMouse();
+            mState.LeftMouseClicked = false;
+            mState.RightMouseClicked = false;
+            State.FrameStates.Add(
+                new FrameState(
+                    new KeyboardState(),
+                    mState.GetMouseState(),
+                    inject: text
+                )
+            );
+            TASInputState.Active = true;
+        }
         public static void Reset(bool fastAdvance=false)
         {
             ModEntry.Console.Log("Calling reset", LogLevel.Error);
@@ -491,7 +505,7 @@ namespace TASMod
             TextBox textBox = TextBoxInput.GetSelected(out string Name);
             if (textBox != null)
             {
-                if (textBox.Text.Length == 0)
+                if (textBox.Text.Length == 0 || State.FrameStates[(int)TASDateTime.CurrentFrame-1].HasInjectText())
                 {
                     switch (Name)
                     {
@@ -505,7 +519,8 @@ namespace TASMod
                             TextBoxInput.Write(textBox, Controller.State.FavoriteThing);
                             break;
                         default:
-                            TextBoxInput.Write(textBox, Name);
+                            string text = State.FrameStates[(int)TASDateTime.CurrentFrame-1].injectText;
+                            TextBoxInput.Write(textBox, text);
                             break;
                     }
                     return true;

--- a/TASMod/Inputs/TextBoxInput.cs
+++ b/TASMod/Inputs/TextBoxInput.cs
@@ -85,6 +85,8 @@ namespace TASMod.Inputs
                         return textBox;
                     }
                 }
+                if (textBox == null)
+                    textBox = (TextBox)Game1.keyboardDispatcher.Subscriber;
             }
             // TODO: Other textbox based events
             if (textBox != null)
@@ -101,6 +103,7 @@ namespace TASMod.Inputs
         {
             if (textBox != null)
             {
+                textBox.Text = "";
                 foreach (char c in text)
                 {
                     textBox.RecieveTextInput(c);

--- a/TASMod/LuaScripting/ScriptInterface.cs
+++ b/TASMod/LuaScripting/ScriptInterface.cs
@@ -153,11 +153,12 @@ namespace TASMod.LuaScripting
         {
             RealInputState.Update();
             WaitPostfix();
-            ReadInputStates(input, out TASKeyboardState kstate, out TASMouseState mstate);
+            ReadInputStates(input, out TASKeyboardState kstate, out TASMouseState mstate, out string injectText);
             Controller.State.FrameStates.Add(
                 new FrameState(
                     kstate.GetKeyboardState(),
-                    mstate.GetMouseState()
+                    mstate.GetMouseState(),
+                    inject: injectText
                 )
             );
             StepLogic();
@@ -174,14 +175,16 @@ namespace TASMod.LuaScripting
             Controller.AcceptRealInput = true;
         }
 
-        public static void ReadInputStates(LuaTable input, out TASKeyboardState kstate, out TASMouseState mstate)
+        public static void ReadInputStates(LuaTable input, out TASKeyboardState kstate, out TASMouseState mstate, out string injectText)
         {
             LuaTable keyboard = null;
             LuaTable mouse = null;
+            injectText = "";
             if (input != null)
             {
                 keyboard = (LuaTable)input["keyboard"];
                 mouse = (LuaTable)input["mouse"];
+                injectText = (string)input["text"];
             }
 
             kstate = new TASKeyboardState();

--- a/TASMod/Patches/KeyboardDispatcher.cs
+++ b/TASMod/Patches/KeyboardDispatcher.cs
@@ -1,0 +1,94 @@
+using HarmonyLib;
+using StardewValley;
+namespace TASMod.Patches
+{
+    public class KeyboardDispatcher_ShouldSuppress : IPatch
+    {
+        public static string BaseKey = "KeyboardDispatcher.ShouldSuppress";
+        public override string Name => BaseKey;
+        public override void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(KeyboardDispatcher), BaseKey.Split(".")[1]),
+                postfix: new HarmonyMethod(this.GetType(), nameof(this.Postfix))
+                );
+        }
+
+        public static void Postfix(ref bool __result)
+        {
+            __result = true;
+        }
+    }
+
+    public class KeyboardDispatcher_Event_TextInput : IPatch
+    {
+        public static string BaseKey = "KeyboardDispatcher.Event_TextInput";
+        public override string Name => BaseKey;
+        public override void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(KeyboardDispatcher), BaseKey.Split(".")[1]),
+                prefix: new HarmonyMethod(this.GetType(), nameof(this.Prefix))
+                );
+        }
+
+        public static bool Prefix()
+        {
+            return false;
+        }
+    }
+
+    public class KeyboardDispatcher_EventInput_CharEntered : IPatch
+    {
+        public static string BaseKey = "KeyboardDispatcher.EventInput_CharEntered";
+        public override string Name => BaseKey;
+        public override void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(KeyboardDispatcher), BaseKey.Split(".")[1]),
+                prefix: new HarmonyMethod(this.GetType(), nameof(this.Prefix))
+                );
+        }
+
+        public static bool Prefix()
+        {
+            return false;
+        }
+    }
+
+    public class KeyboardDispatcher_EventInput_KeyDown : IPatch
+    {
+        public static string BaseKey = "KeyboardDispatcher.EventInput_KeyDown";
+        public override string Name => BaseKey;
+        public override void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(KeyboardDispatcher), BaseKey.Split(".")[1]),
+                prefix: new HarmonyMethod(this.GetType(), nameof(this.Prefix))
+                );
+        }
+
+        public static bool Prefix()
+        {
+            return false;
+        }
+    }
+
+    public class KeyboardDispatcher_Event_KeyDown : IPatch
+    {
+        public static string BaseKey = "KeyboardDispatcher.Event_KeyDown";
+        public override string Name => BaseKey;
+        public override void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(KeyboardDispatcher), BaseKey.Split(".")[1]),
+                prefix: new HarmonyMethod(this.GetType(), nameof(this.Prefix))
+                );
+        }
+
+        public static bool Prefix()
+        {
+            return false;
+        }
+    }
+}

--- a/TASMod/Recording/FrameState.cs
+++ b/TASMod/Recording/FrameState.cs
@@ -63,6 +63,9 @@ namespace TASMod.Recording
         [JsonProperty]
         public TASMouseState mouseState;
         public string comments;
+        [JsonProperty]
+        public string injectText;
+        public string InjectText { get => injectText; set => injectText = value; }
 
         public FrameState()
         {
@@ -70,6 +73,7 @@ namespace TASMod.Recording
             keyboardState = new TASKeyboardState();
             mouseState = new TASMouseState();
             comments = "";
+            injectText = "";
         }
 
         public FrameState(FrameState o)
@@ -82,15 +86,30 @@ namespace TASMod.Recording
             keyboardState.IntersectWith(ValidKeys);
             mouseState = new TASMouseState(o.mouseState);
             comments = o.comments;
+            injectText = o.injectText;
         }
 
-        public FrameState(KeyboardState kstate, MouseState mstate, string comm = "")
+        public FrameState(KeyboardState kstate, MouseState mstate, string comm = "", string inject = "")
         {
             randomState = new RandomState(Game1.random);
             keyboardState = new TASKeyboardState(kstate);
             keyboardState.IntersectWith(ValidKeys);
             mouseState = new TASMouseState(mstate);
             comments = comm;
+            injectText = inject;
+        }
+
+        public bool HasInjectText()
+        {
+            return !string.IsNullOrEmpty(injectText);
+        }
+        public void SetInjectText(string text)
+        {
+            injectText = text;
+        }
+        public void ClearInjectText()
+        {
+            injectText = "";
         }
 
         public void toStates(out TASKeyboardState kstate, out TASMouseState mstate)
@@ -119,9 +138,10 @@ namespace TASMod.Recording
         {
             if (obj is FrameState state)
             {
-                return (state.keyboardState.SetEquals(keyboardState))
-                    && (state.mouseState.Equals(mouseState))
-                    && state.randomState.Equals(randomState);
+                return state.keyboardState.SetEquals(keyboardState)
+                    && state.mouseState.Equals(mouseState)
+                    && state.randomState.Equals(randomState)
+                    && state.injectText == injectText;
             }
             return false;
         }


### PR DESCRIPTION
* adds another optional field `text` to the `advance({...})` command
  * `advance({text="..."})` will attempt to write text into an active textbox on this frame (stored as `injectText` in the input file json)
* adds default console command `textbox value` to enter data into the active textbox

also fixes a bug where if a textbox was open, it would capture ALL keyboard commands regardless (because it was happening based on window events, not the desired "input")